### PR TITLE
Fix：当条目内容为空时，TOC 插件报错

### DIFF
--- a/plugins/Gk0Wk/page-toc/PageTOCWidget.js
+++ b/plugins/Gk0Wk/page-toc/PageTOCWidget.js
@@ -24,6 +24,8 @@
       h6: 0,
     };
     var root = $tw.wiki.parseTiddler(tiddler).tree;
+    if (root.length == 0)
+      return undefined;
     var renderRoot = [],
       renderLeaf = renderRoot;
     // Parse params


### PR DESCRIPTION
当条目内容为空时，TOC 插件会报错。

![image](https://user-images.githubusercontent.com/9380918/187682532-f12d38c6-4546-428d-be45-5929ccb65de2.png)

```
TypeError: Cannot read properties of undefined (reading 'type')
```
